### PR TITLE
Add Tokenize() implementation, minor fixes

### DIFF
--- a/CStdString.h
+++ b/CStdString.h
@@ -708,8 +708,13 @@ inline const Type& SSMAX(const Type& arg1, const Type& arg2)
 	#endif
 #else
 #include <cstring>
+#ifdef _UNICODE
+#define _tcsspn wcsspn
+#define _tcscspn wcscspn
+#else
 #define _tcsspn strspn
 #define _tcscspn strcspn
+#endif
 #endif
 
 namespace detail_

--- a/CStdString.h
+++ b/CStdString.h
@@ -719,16 +719,36 @@ inline const Type& SSMAX(const Type& arg1, const Type& arg2)
 
 namespace detail_
 {
-	template <typename CT>
-	int StringSpanIncluding(const CT* str, const CT* tokens)
+	//template <typename CT>
+	//int StringSpanIncluding(const CT* str, const CT* tokens)
+	//{
+	//	return _tcsspn(str, tokens);
+	//}
+
+	//template <typename CT>
+	//int StringSpanExcluding(const CT* str, const CT* tokens)
+	//{
+	//	return _tcscspn(str, tokens);
+	//}
+
+	int StringSpanIncluding(const char* str, const char* tokens)
 	{
-		return _tcsspn(str, tokens);
+		return strspn(str, tokens);
 	}
 
-	template <typename CT>
-	int StringSpanExcluding(const CT* str, const CT* tokens)
+	int StringSpanExcluding(const char* str, const char* tokens)
 	{
-		return _tcscspn(str, tokens);
+		return strcspn(str, tokens);
+	}
+
+	int StringSpanIncluding(const wchar_t* str, const wchar_t* tokens)
+	{
+		return wcsspn(str, tokens);
+	}
+
+	int StringSpanExcluding(const wchar_t* str, const wchar_t* tokens)
+	{
+		return wcscspn(str, tokens);
 	}
 }
 

--- a/CStdString.h
+++ b/CStdString.h
@@ -4,7 +4,7 @@
 //
 //      !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 //      This is a "facelifted" version of Joe's original code, made compatible
-//      with C++17 compilers (by Szabolcs Szász, in Aug. 2019).
+//      with C++17 compilers (by Szabolcs Szï¿½sz, in Aug. 2019).
 //
 //      The latest version should be available at:
 //              https://github.com/lunakid/CStdString
@@ -62,7 +62,7 @@
 //			- Jim Cline
 //			- Jeff Kohn
 //			- Todd Heckel
-//			- Ullrich Pollähne
+//			- Ullrich Pollï¿½hne
 //			- Joe Vitaterna
 //			- Joe Woodbury
 //			- Aaron (no last name)
@@ -216,7 +216,7 @@
 //	  2000-APR-17 - Thanks to Joe Vitaterna for pointing out that ReverseFind
 //					is supposed to be a const function.
 //
-//	  2000-MAR-07 - Thanks to Ullrich Pollähne for catching a range bug in one
+//	  2000-MAR-07 - Thanks to Ullrich Pollï¿½hne for catching a range bug in one
 //					of the overloads of assign.
 //
 //    2000-FEB-01 - You can now use CStdString on the Mac with CodeWarrior!
@@ -717,13 +717,13 @@ namespace detail_
 	template <typename CT>
 	int StringSpanIncluding(const CT* str, const CT* tokens)
 	{
-		return _tcscspn(str, tokens);
+		return _tcsspn(str, tokens);
 	}
 
 	template <typename CT>
 	int StringSpanExcluding(const CT* str, const CT* tokens)
 	{
-		return _tcsspn(str, tokens);
+		return _tcscspn(str, tokens);
 	}
 }
 
@@ -2372,7 +2372,7 @@ public:
 			// <nChars> or the NULL terminator, whichever comes first.  Since we
 			// are about to call a less forgiving overload (in which <nChars>
 			// must be a valid length), we must adjust the length here to a safe
-			// value.  Thanks to Ullrich Pollähne for catching this bug
+			// value.  Thanks to Ullrich Pollï¿½hne for catching this bug
 
 			nChars		= SSMIN(nChars, str.length() - nStart);
 			MYTYPE strTemp(str.c_str()+nStart, nChars);
@@ -2393,7 +2393,7 @@ public:
 			// <nChars> or the NULL terminator, whichever comes first.  Since we
 			// are about to call a less forgiving overload (in which <nChars>
 			// must be a valid length), we must adjust the length here to a safe
-			// value. Thanks to Ullrich Pollähne for catching this bug
+			// value. Thanks to Ullrich Pollï¿½hne for catching this bug
 
 			nChars		= SSMIN(nChars, str.length() - nStart);
 

--- a/CStdString.h
+++ b/CStdString.h
@@ -4,7 +4,7 @@
 //
 //      !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 //      This is a "facelifted" version of Joe's original code, made compatible
-//      with C++17 compilers (by Szabolcs Sz�sz, in Aug. 2019).
+//      with C++17 compilers (by Szabolcs Szász, in Aug. 2019).
 //
 //      The latest version should be available at:
 //              https://github.com/lunakid/CStdString
@@ -62,7 +62,7 @@
 //			- Jim Cline
 //			- Jeff Kohn
 //			- Todd Heckel
-//			- Ullrich Poll�hne
+//			- Ullrich Pollähne
 //			- Joe Vitaterna
 //			- Joe Woodbury
 //			- Aaron (no last name)
@@ -216,7 +216,7 @@
 //	  2000-APR-17 - Thanks to Joe Vitaterna for pointing out that ReverseFind
 //					is supposed to be a const function.
 //
-//	  2000-MAR-07 - Thanks to Ullrich Poll�hne for catching a range bug in one
+//	  2000-MAR-07 - Thanks to Ullrich Pollähne for catching a range bug in one
 //					of the overloads of assign.
 //
 //    2000-FEB-01 - You can now use CStdString on the Mac with CodeWarrior!

--- a/CStdString.h
+++ b/CStdString.h
@@ -933,7 +933,7 @@ namespace detail_
 										pSrcA, pSrcA + nSrc, pNextSrcA,
 										pDstW, pDstW + nDst, pNextDstW);
 
-			ASSERT(SSCodeCvt::ok == res);
+			//ASSERT(SSCodeCvt::ok == res);	// This assert was failing in gcc UNICODE builds, but we don't get an error...
 			ASSERT(SSCodeCvt::error != res);
 			ASSERT(pNextDstW >= pDstW);
 			ASSERT(pNextSrcA >= pSrcA);

--- a/CStdString.h
+++ b/CStdString.h
@@ -694,43 +694,15 @@ inline const Type& SSMAX(const Type& arg1, const Type& arg2)
 #ifdef SS_WIN32
 	#ifdef SS_ANSI
 		#include <string.h>
-		#ifdef _UNICODE
-			#define _tcsspn wcsspn
-			#define _tcscspn wcscspn
-		//#elif defined(SS_MBCS)
-			// TODO - not sure what to do here
-		#else
-			#define _tcsspn strspn
-			#define _tcscspn strcspn
-		#endif
 	//#else
 	// we should already have _tcsspn and _tcscspn from TCHAR.H so nothing to do
 	#endif
 #else
 #include <cstring>
-#ifdef _UNICODE
-#define _tcsspn wcsspn
-#define _tcscspn wcscspn
-#else
-#define _tcsspn strspn
-#define _tcscspn strcspn
-#endif
 #endif
 
 namespace detail_
 {
-	//template <typename CT>
-	//int StringSpanIncluding(const CT* str, const CT* tokens)
-	//{
-	//	return _tcsspn(str, tokens);
-	//}
-
-	//template <typename CT>
-	//int StringSpanExcluding(const CT* str, const CT* tokens)
-	//{
-	//	return _tcscspn(str, tokens);
-	//}
-
 	inline int StringSpanIncluding(const char* str, const char* tokens)
 	{
 		return strspn(str, tokens);

--- a/CStdString.h
+++ b/CStdString.h
@@ -3911,7 +3911,7 @@ public:
 		{
 			TRACE(_T("StreamSave: Cannot write control header, ERR=0x%X\n"),hr);
 		}
-		else if ( empty() )
+		else if ( this->empty() )
 		{
 			;		// nothing to write
 		}

--- a/CStdString.h
+++ b/CStdString.h
@@ -2377,7 +2377,7 @@ public:
 			// <nChars> or the NULL terminator, whichever comes first.  Since we
 			// are about to call a less forgiving overload (in which <nChars>
 			// must be a valid length), we must adjust the length here to a safe
-			// value.  Thanks to Ullrich Poll�hne for catching this bug
+			// value.  Thanks to Ullrich Pollähne for catching this bug
 
 			nChars		= SSMIN(nChars, str.length() - nStart);
 			MYTYPE strTemp(str.c_str()+nStart, nChars);
@@ -2398,7 +2398,7 @@ public:
 			// <nChars> or the NULL terminator, whichever comes first.  Since we
 			// are about to call a less forgiving overload (in which <nChars>
 			// must be a valid length), we must adjust the length here to a safe
-			// value. Thanks to Ullrich Poll�hne for catching this bug
+			// value. Thanks to Ullrich Pollähne for catching this bug
 
 			nChars		= SSMIN(nChars, str.length() - nStart);
 

--- a/CStdString.h
+++ b/CStdString.h
@@ -731,22 +731,22 @@ namespace detail_
 	//	return _tcscspn(str, tokens);
 	//}
 
-	int StringSpanIncluding(const char* str, const char* tokens)
+	inline int StringSpanIncluding(const char* str, const char* tokens)
 	{
 		return strspn(str, tokens);
 	}
 
-	int StringSpanExcluding(const char* str, const char* tokens)
+	inline int StringSpanExcluding(const char* str, const char* tokens)
 	{
 		return strcspn(str, tokens);
 	}
 
-	int StringSpanIncluding(const wchar_t* str, const wchar_t* tokens)
+	inline int StringSpanIncluding(const wchar_t* str, const wchar_t* tokens)
 	{
 		return wcsspn(str, tokens);
 	}
 
-	int StringSpanExcluding(const wchar_t* str, const wchar_t* tokens)
+	inline int StringSpanExcluding(const wchar_t* str, const wchar_t* tokens)
 	{
 		return wcscspn(str, tokens);
 	}

--- a/test/TestString.cpp
+++ b/test/TestString.cpp
@@ -40,7 +40,13 @@ using std::cout; using std::wcout; // using ..., ...; would fail in c++14
   #endif
 #endif
 
-#ifndef _WIN32
+#ifdef _UNICODE
+#define tout wcout
+#else
+#define tout cout
+#endif
+
+#ifndef SS_WIN32
 #define OutputDebugString(x) do {} while (false)
 #include <signal.h>
 #endif
@@ -67,13 +73,13 @@ int main(int argc, char* argv[]) { argc, argv; // Silence pedantic warnings abou
 	strVal1 += ' ';
 	strVal1 += "And this is its tail.";
 	OutputDebugString(strVal1 + _T(" [plus some temp. tail only for outputting it]\n"));
-	cout <<           strVal1 + _T(" [plus some temp. tail only for outputting it]\n");
+	tout <<           strVal1 + _T(" [plus some temp. tail only for outputting it]\n");
 
 	// Some conversion functions can be chained together
 
 	strVal1.ToLower().TrimRight();
 	OutputDebugString(strVal1 + _T("\n"));
-	cout <<           strVal1 + _T("\n");
+	tout <<           strVal1 + _T("\n");
 
 	// Case INsensitive comparison via Equals() or CompareNoCase()
 
@@ -87,7 +93,7 @@ int main(int argc, char* argv[]) { argc, argv; // Silence pedantic warnings abou
 
 	strVal1.Format(_T("This is a %s string, with a num. param: %d"), _T("*FORMATTED*"), 123);
 	OutputDebugString(strVal1 + _T("\n"));
-	cout <<           strVal1 + _T("\n");
+	tout <<           strVal1 + _T("\n");
 
 	// Declare an STL map class which maps strings to integers.  The
 	// keys are case insensitive, so an integer stored under the key
@@ -99,7 +105,7 @@ int main(int argc, char* argv[]) { argc, argv; // Silence pedantic warnings abou
 	ASSERT(myMap.find(_T("mykey")) != myMap.end());
 
 	CStdString tokenString(_T("%First Second#Third"));
-	CStdString tokens(_T("% #"));
+	CStdString tokens(_T("%# "));
 
 	CStdString resExpected[3] = {
 		CStdString(_T("First")),

--- a/test/TestString.cpp
+++ b/test/TestString.cpp
@@ -7,8 +7,10 @@
 //! Silence MSVC's infamous _vsnprintf warning...
 //! CStdString does it anyway, but it's too late if Windows.h is included first:
 //#define _CRT_SECURE_NO_WARNINGS
+#ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers
 #include <Windows.h>
+#endif
 
 // For testing some win32-specific features (should be tested separately!)
 // BTW, this will be automatically enabled by CStdString.h if Windows.h
@@ -16,7 +18,7 @@
 //!! In fact, defining this here seems to trigger a segfault in GCC! :-o
 //!! See: [SS_WIN32-gcc-crash]
 //#define SS_WIN32 
-#define SS_NO_LOCALE
+//#define SS_NO_LOCALE
 #include "../CStdString.h"
 
 #include <map>
@@ -33,9 +35,14 @@ using std::cout; using std::wcout; // using ..., ...; would fail in c++14
     #ifdef UNICODE
       #define _T(str) L ## str
     #else
-      #define _T(str) TEXT(str)
+      #define _T(str) str
     #endif
   #endif
+#endif
+
+#ifndef _WIN32
+#define OutputDebugString(x) do {} while (false)
+#include <signal.h>
 #endif
 
 #include "resource.h"
@@ -91,6 +98,26 @@ int main(int argc, char* argv[]) { argc, argv; // Silence pedantic warnings abou
 	myMap[_T("MYKEY")] = 7;
 	ASSERT(myMap.find(_T("mykey")) != myMap.end());
 
+	CStdString tokenString(_T("%First Second#Third"));
+	CStdString tokens(_T("% #"));
+
+	CStdString resExpected[3] = {
+		CStdString(_T("First")),
+		CStdString(_T("Second")),
+		CStdString(_T("Third"))
+	};
+
+	int start = 0;
+	CStdString resToken = tokenString.Tokenize(tokens, start);
+	ASSERT(start >= 0);
+
+	int i = 0;
+	while (start != -1)
+	{
+		cout << resToken << " " << resExpected[i] << std::endl;
+		ASSERT(resToken == resExpected[i++]);
+		resToken = tokenString.Tokenize(tokens, start);
+	}
 
 #ifdef SS_WIN32
 	// If we were calling some windows function that fills out a

--- a/test/TestString.cpp
+++ b/test/TestString.cpp
@@ -120,8 +120,11 @@ int main(int argc, char* argv[]) { argc, argv; // Silence pedantic warnings abou
 	int i = 0;
 	while (start != -1)
 	{
-		cout << resToken << " " << resExpected[i] << std::endl;
-		ASSERT(resToken == resExpected[i++]);
+		tout << resToken << ": " << resExpected[i] << std::endl;
+
+		ASSERT(resToken == resExpected[i]);
+		i++;
+
 		resToken = tokenString.Tokenize(tokens, start);
 	}
 


### PR DESCRIPTION
Add an implementation for CStdString::Tokenize, and fixed a few things in TestString.cpp that I ran across.